### PR TITLE
init comments 

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -58,6 +58,8 @@ const Home = props => {
   )
 }
 
+
+// getInitialProps should be getStaticPorps or getServerSideProps
 Home.getInitialProps = async ({ req }) => {
 
   const { origin } = absoluteUrl(req)

--- a/pages/leg.js
+++ b/pages/leg.js
@@ -121,7 +121,7 @@ const NewLeg = props => {
   const handleInputChange = event => {
     setFormState({ ...formState, [event.target.name]: event.target.value })
   }
-
+// I think this a simple and nice way to handle form validation, without adding a library that could make it more robust, but also more difficult to work with. 
   const validation = () => {
     let errors = {}
 

--- a/pages/leg.js
+++ b/pages/leg.js
@@ -104,7 +104,7 @@ const NewLeg = props => {
   
   const addLeg = async () => {
     try {
-      const res = await fetch(`${props.path}/api/legs`, {
+      const res = await fetch(`${props.path}/api/legs`, {  // unused variable 
         method: 'POST',
         headers: {
           'Accept': 'application/json',

--- a/src/components/Flights.js
+++ b/src/components/Flights.js
@@ -52,7 +52,7 @@ const Flights = props => {
     selected: props.itineraries,
     agent: 'all',
     totalPrice: props.itineraries.map(itinerary => itinerary.price).reduce((sum, current) => sum + current, 0).toFixed(2),
-    avgPrice: (props.itineraries.map(itinerary => itinerary.price).reduce((sum, current) => sum + current, 0) / props.itineraries.length).toFixed(2)
+    avgPrice: (props.itineraries.map(itinerary => itinerary.price).reduce((sum, current) => sum + current, 0) / props.itineraries.length).toFixed(2) // if there is no itineraries, this will render as NaN - rather than '0.00' like average price 
   })
 
   const handleAgentChange = event => {
@@ -163,11 +163,11 @@ const Flights = props => {
           Total Price: <span className={classes.prices}>&pound;{flightsState.totalPrice}</span>
         </Typography>
         <Typography variant="button" color="secondary">
-          Average Price: <span className={classes.prices}>&pound;{flightsState.avgPrice}</span>
+          Average Price: <span className={classes.prices}>&pound;{flightsState.avgPrice}</span> 
         </Typography>
       </Grid>
     </Grid>
   )
 }
-
+// line:  166 - When there are no itineries, it shows NAN, rather thatn 0.00 like Total Price
 export default Flights

--- a/src/components/Flights.js
+++ b/src/components/Flights.js
@@ -46,7 +46,7 @@ const Flights = props => {
   
   const classes = useStyles()
 
-  let agentChoices = Array.from(new Set(props.itineraries.map(itinerary => itinerary.agent)))
+  let agentChoices = Array.from(new Set(props.itineraries.map(itinerary => itinerary.agent))) // the use of a Set to ensure uniqe values
   
   const [flightsState, setFlightsState] = useState({
     selected: props.itineraries,

--- a/src/components/Itinerary.js
+++ b/src/components/Itinerary.js
@@ -63,7 +63,7 @@ const Itinerary = props => {
       >
         {/* Leg 1 */}
         <Leg 
-          leg={props.legs.find(leg => leg._id === props.itinerary.legs[0])}
+          leg={props.legs.find(leg => leg._id === props.itinerary.legs[0])} // Need to handle the Itinerary property not being here - if you delete the Itinerary, and go back to the delete page page - it will throw an unhanlded exception, should route to home page or show message "nothing to delete"
           access={props.access}
         />
         <hr/>

--- a/src/components/Leg.js
+++ b/src/components/Leg.js
@@ -68,7 +68,7 @@ const Leg = (props) => {
       >
         {/* Airline Logo */}
         <img 
-          src={`https://logos.skyscnr.com/images/airlines/favicon/${props.leg.airlineId}.png`} 
+          src={`https://logos.skyscnr.com/images/airlines/favicon/${props.leg.airlineId}.png`} // Need to handle the Leg property not being here - if you delete the Leg, and go back to the delete page - it will throw an unhanlded exception, should route to home page or show message "nothing to delete".
           alt="Airline Logo"
           className={classes.logo}
         />


### PR DESCRIPTION
## ISSUES:
    1. ‘ClassNames’ for styles not matching between the server and client  Issue around SSR and MaterialUI. MaterialUI — 
    generates Dynamic class names containing an ID on the server, not matching the ID on the client. Next JS producing 
    the styles before the page is rendered. 
        Solution:  create a custom Document pulling out the CSS that was generated on the server and pass the styles  
          down to client 
 
     2. `getInitialProps` should be replaced with `getStaticProps` or `getServerSideProps`
  
     3.  The `Stops` property in `/legs`, should give an error, prompting use to enter a numeric value, rather than 
           rendering `NaN`

     4. navigating back to a `/delete`, after deleting an itinerary or leg will throw an unhandled exception 
     
     5. `Average Price`, will render `NaN` if there are no Itineraries  

     6.  A USER should NOT be able to pick an `Arrival Time` later than the `Departure Time` 